### PR TITLE
Fix fetch list twice issue

### DIFF
--- a/ghissues.js
+++ b/ghissues.js
@@ -65,7 +65,7 @@ module.exports.list = function list (auth, org, repo, options, callback) {
 
       next(page + 1)
     })
-  }(0))
+  }(1))
 }
 
 


### PR DESCRIPTION
`page=0` and `page=1` returns same result due to `?page=0` is invalid.
Changed initial page to 1, how about this?

thanks
